### PR TITLE
Fix off-by-one error in miniFAT stream cutoff size

### DIFF
--- a/include/cfb.hpp
+++ b/include/cfb.hpp
@@ -690,7 +690,7 @@ struct DirectoryEntryVec : std::vector<DirectoryEntry> {
 					const uint32_t pos = dir.startingSectorLocation;
 
 					const UintVec *v;
-					if (dir.streamSize <= cutoffSize && (v = miniFats.query(pos)) != 0) {
+					if (dir.streamSize < cutoffSize && (v = miniFats.query(pos)) != 0) {
 						load(dir.content, &miniData[0], dir.streamSize, *v, miniSectorSize);
 					} else {
 						load(dir.content, data, dir.streamSize, fats.get(pos), sectorSize);


### PR DESCRIPTION
When the stream size is exactly 4096, data should be loaded from FAT (not from MiniFAT).

> Mini Stream Cutoff Size (4 bytes): This integer field MUST be set to 0x00001000. This field specifies the maximum size of a user-defined data stream that is allocated from the mini FAT and mini stream, and that cutoff is 4,096 bytes. Any user-defined data stream that is greater than or equal to this cutoff size must be allocated as normal sectors from the FAT.

https://msdn.microsoft.com/en-us/library/dd941946.aspx
