### PR TITLE
Add shared-lib target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,18 @@ clean:
 
 MSOC_LIB=lib/libmsoc.a
 $(MSOC_LIB): src/msocdll.cpp include/msoc.h
+	$(MKDIR) lib src/$(OBJDIR)
 	$(CXX) -c $(CFLAGS) -fPIC src/msocdll.cpp -o src/$(OBJDIR)/msocdll.o
 	$(MKDIR) lib
 	$(AR) $(MSOC_LIB) src/$(OBJDIR)/msocdll.o
+
+
+MSOC_SHARED_LIB=lib/libmsoc.$(DLL_SUFFIX)
+$(MSOC_SHARED_LIB): src/msocdll.cpp include/msoc.h
+	$(MKDIR) lib src/$(OBJDIR)
+	$(CXX) -c $(CFLAGS) -fPIC src/msocdll.cpp -o src/$(OBJDIR)/msocdll.o
+	$(MKDIR) lib
+	$(CXX) -shared -o $(MSOC_SHARED_LIB) src/$(OBJDIR)/msocdll.o $(LDFLAGS)
 
 bin/minisample: src/minisample.c include/msoc.h $(MSOC_LIB)
 	$(CC) $< -o $@ $(MSOC_LIB) -lstdc++ -lcrypto -Iinclude -Wall -Wextra -lcrypto

--- a/common.mk
+++ b/common.mk
@@ -12,6 +12,9 @@ UNAME_S=$(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
   CFLAGS+=-I/usr/local/opt/openssl/include
   LDFLAGS+=-L/usr/local/opt/openssl/lib
+  DLL_SUFFIX=dylib
+else
+  DLL_SUFFIX=so
 endif
 
 DEBUG=0


### PR DESCRIPTION
With this patch, `make lib/libmsoc.dylib` works for my macOS.
`make lib/libmsoc.so` would also work for Linux (I hope).
